### PR TITLE
Add check for rotate tag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/AlexEidt/Vidio
+module github.com/lgaribaldi/Vidio
 
 go 1.16

--- a/video.go
+++ b/video.go
@@ -168,6 +168,9 @@ func (video *Video) addVideoData(data map[string]string) {
 	if height, ok := data["height"]; ok {
 		video.height = int(parse(height))
 	}
+	if rotation, ok := data["tag:rotate"]; ok && rotation == "90" || rotation == "270" {
+		video.width, video.height = video.height, video.width
+	}
 	if duration, ok := data["duration"]; ok {
 		video.duration = float64(parse(duration))
 	}


### PR DESCRIPTION
When a video has a "rotate" tag in metadata, the video player rotates when playing the video, giving it a portrait perspective. Because of this, the width is still larger than height even in a portrait video. Which causes the stride to be off and the resulting frame to be scrambled. This can be fixed by inverting the width and height of the video when there is a rotation.

Fix for #10 